### PR TITLE
test on CI

### DIFF
--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -31,9 +31,9 @@ jobs:
           # Cache dir setting
           TAR_NAME="${IMAGE_NAME}_${VARIANT}.tar"
           TAR_PATH="${{ env.PATH_CACHE }}/${TAR_NAME}"
-          echo "::set-output name=TAG::${TAG}"
-          echo "::set-output name=IMAGE_NAME::${IMAGE_NAME}"
-          echo "::set-output name=TAR_PATH::${TAR_PATH}"
+          echo "TAG=${TAG}" >> $GITHUB_OUTPUT
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "TAR_PATH=${TAR_PATH}" >> $GITHUB_OUTPUT
 
       - name: Enable cache
         id: cache

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -21,7 +21,7 @@ jobs:
         id: image_tag
         run: |
           # Define cache dir
-          PATH_CACHE="/tmp/docker_cache_${{ env.ARCH }}"
+          CACHE_PATH="/tmp/docker_cache_${{ env.ARCH }}"
           # Get Dockerfile hash for image cache
           IMAGE_HASH="${{ hashFiles('./Dockerfile') }}"
           # Create image tag
@@ -30,16 +30,17 @@ jobs:
           TAG="${IMAGE_NAME}:${VARIANT}"
           # Cache dir setting
           TAR_NAME="${IMAGE_NAME}_${VARIANT}.tar"
-          TAR_PATH="${{ env.PATH_CACHE }}/${TAR_NAME}"
+          TAR_PATH="${{ env.CACHE_PATH }}/${TAR_NAME}"
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "TAR_PATH=${TAR_PATH}" >> $GITHUB_OUTPUT
+          echo "CACHE_PATH=${CACHE_PATH}" >> $GITHUB_OUTPUT
 
       - name: Enable cache
         id: cache
         uses: actions/cache@v2
         with:
-          path: ${{ env.PATH_CACHE }}
+          path: ${{ steps.image_tag.outputs.CACHE_PATH }}
           key: ${{ steps.image_tag.outputs.IMAGE_NAME }}-${{ env.ARCH }}
 
       - name: Load image from cache if exists
@@ -51,7 +52,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           docker build -t ${{ steps.image_tag.outputs.TAG }} .
-          mkdir -p ${{ env.PATH_CACHE }}
+          mkdir -p ${{ steps.image_tag.outputs.CACHE_PATH }}
           docker save ${{ steps.image_tag.outputs.TAG }} > ${{ steps.image_tag.outputs.TAR_PATH }}
 
       - name: Run tests in container

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -30,7 +30,7 @@ jobs:
           TAG="${IMAGE_NAME}:${VARIANT}"
           # Cache dir setting
           TAR_NAME="${IMAGE_NAME}_${VARIANT}.tar"
-          TAR_PATH="${{ env.CACHE_PATH }}/${TAR_NAME}"
+          TAR_PATH="${CACHE_PATH}/${TAR_NAME}"
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "TAR_PATH=${TAR_PATH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -35,13 +35,14 @@ jobs:
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "TAR_PATH=${TAR_PATH}" >> $GITHUB_OUTPUT
           echo "CACHE_PATH=${CACHE_PATH}" >> $GITHUB_OUTPUT
+          echo "CACHE_KEY=${IMAGE_NAME}_${VARIANT}" >> $GITHUB_OUTPUT
 
       - name: Enable cache
         id: cache
         uses: actions/cache@v3
         with:
           path: ${{ steps.image_tag.outputs.CACHE_PATH }}
-          key: ${{ steps.image_tag.outputs.IMAGE_NAME }}-${{ env.ARCH }}
+          key: ${{ steps.image_tag.outputs.CACHE_KEY }}
 
       - name: Load image from cache if exists
         if: steps.cache.outputs.cache-hit == 'true'

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create image tag
         id: image_tag
@@ -38,7 +38,7 @@ jobs:
 
       - name: Enable cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.image_tag.outputs.CACHE_PATH }}
           key: ${{ steps.image_tag.outputs.IMAGE_NAME }}-${{ env.ARCH }}

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -55,6 +55,12 @@ jobs:
           mkdir -p ${{ steps.image_tag.outputs.CACHE_PATH }}
           docker save ${{ steps.image_tag.outputs.TAG }} > ${{ steps.image_tag.outputs.TAR_PATH }}
 
+      - name: whoami
+        run: |
+          whoami
+
       - name: Run tests in container
         run: |
+          ls -la
+          docker run --rm -v ${{ github.workspace }}:/work -w /work  ${{ steps.image_tag.outputs.TAG }} ls -la
           docker run --rm -v ${{ github.workspace }}:/work -w /work  ${{ steps.image_tag.outputs.TAG }} make test

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Run tests in container
         run: |
-          ls -la
+          # Change owner of workspace
+          sudo chown -R 1000:1000 ${{ github.workspace }}
           docker run --rm -v ${{ github.workspace }}:/work -w /work  ${{ steps.image_tag.outputs.TAG }} ls -la
           docker run --rm -v ${{ github.workspace }}:/work -w /work  ${{ steps.image_tag.outputs.TAG }} make test

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -8,20 +8,22 @@ on:
 
 env:
   ARCH: x64
-  PATH_CACHE: /tmp/docker_cache_${{ env.ARCH }}
 
 jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Create image tag
         id: image_tag
         run: |
+          # Define cache dir
+          PATH_CACHE="/tmp/docker_cache_${{ env.ARCH }}"
           # Get Dockerfile hash for image cache
-          IMAGE_HASH=${{ hashFiles('./Dockerfile') }}
+          IMAGE_HASH="${{ hashFiles('./Dockerfile') }}"
           # Create image tag
           VARIANT="$(TZ=UTC-9 date +%Y%m%d)_${IMAGE_HASH:0:7}"
           IMAGE_NAME="slcc_cmake_${{ env.ARCH }}"

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -55,13 +55,8 @@ jobs:
           mkdir -p ${{ steps.image_tag.outputs.CACHE_PATH }}
           docker save ${{ steps.image_tag.outputs.TAG }} > ${{ steps.image_tag.outputs.TAR_PATH }}
 
-      - name: whoami
-        run: |
-          whoami
-
       - name: Run tests in container
         run: |
-          # Change owner of workspace
+          # Change owner of workspace to ubuntu user
           sudo chown -R 1000:1000 ${{ github.workspace }}
-          docker run --rm -v ${{ github.workspace }}:/work -w /work  ${{ steps.image_tag.outputs.TAG }} ls -la
           docker run --rm -v ${{ github.workspace }}:/work -w /work  ${{ steps.image_tag.outputs.TAG }} make test

--- a/.github/workflows/cmake_x64.yml
+++ b/.github/workflows/cmake_x64.yml
@@ -1,0 +1,57 @@
+name: CMake_x64
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  ARCH: x64
+  PATH_CACHE: /tmp/docker_cache_${{ env.ARCH }}
+
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create image tag
+        id: image_tag
+        run: |
+          # Get Dockerfile hash for image cache
+          IMAGE_HASH=${{ hashFiles('./Dockerfile') }}
+          # Create image tag
+          VARIANT="$(TZ=UTC-9 date +%Y%m%d)_${IMAGE_HASH:0:7}"
+          IMAGE_NAME="slcc_cmake_${{ env.ARCH }}"
+          TAG="${IMAGE_NAME}:${VARIANT}"
+          # Cache dir setting
+          TAR_NAME="${IMAGE_NAME}_${VARIANT}.tar"
+          TAR_PATH="${{ env.PATH_CACHE }}/${TAR_NAME}"
+          echo "::set-output name=TAG::${TAG}"
+          echo "::set-output name=IMAGE_NAME::${IMAGE_NAME}"
+          echo "::set-output name=TAR_PATH::${TAR_PATH}"
+
+      - name: Enable cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.PATH_CACHE }}
+          key: ${{ steps.image_tag.outputs.IMAGE_NAME }}-${{ env.ARCH }}
+
+      - name: Load image from cache if exists
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          docker load -i ${{ steps.image_tag.outputs.TAR_PATH }}
+
+      - name: Build image if cache does not exist
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          docker build -t ${{ steps.image_tag.outputs.TAG }} .
+          mkdir -p ${{ env.PATH_CACHE }}
+          docker save ${{ steps.image_tag.outputs.TAG }} > ${{ steps.image_tag.outputs.TAR_PATH }}
+
+      - name: Run tests in container
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/work -w /work  ${{ steps.image_tag.outputs.TAG }} make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,16 @@
 #   docker build -t slcc .
 FROM ubuntu:22.04
 
-RUN apt update && apt upgrade -y
-RUN apt install -y locales tzdata
-
-# Japanese environment
-RUN locale-gen ja_JP.UTF-8
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y locales tzdata \
+  && locale-gen ja_JP.UTF-8
 ENV LANG ja_JP.UTF-8
 ENV LANGUAGE ja_JP:ja
 ENV LC_ALL ja_JP.UTF-8
 
-RUN apt install -y zsh gcc make git binutils libc6-dev gdb sudo
+RUN apt-get install -y zsh gcc make git binutils libc6-dev gdb sudo
 
-ENV USER=ubuntu GROUP=ubuntu
-RUN groupadd -g 1000 -r $GROUP && \
-  useradd --create-home --no-log-init -r -s /bin/zsh -u 1000 -g $GROUP $USER
+RUN useradd -m -s /bin/zsh ubuntu
 
 USER ubuntu
 WORKDIR /home/ubuntu

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get upgrade -y \
-  && apt-get install -y locales tzdata \
+  && apt-get install -y --no-install-recommends locales \
+  tzdata \
   && locale-gen ja_JP.UTF-8
 ENV LANG ja_JP.UTF-8
 ENV LANGUAGE ja_JP:ja
 ENV LC_ALL ja_JP.UTF-8
 
-RUN apt-get install -y zsh gcc make git binutils libc6-dev gdb sudo
-
-RUN useradd -m -s /bin/zsh ubuntu
+RUN apt-get install -y --no-install-recommends zsh gcc make git binutils libc6-dev gdb sudo \
+  && useradd -m -s /bin/zsh ubuntu
 
 USER ubuntu
 WORKDIR /home/ubuntu


### PR DESCRIPTION
Test for GitHubActions

- Build Dockerfile and save the cache if the cache does not exist
  - Restore and load cache if the cache is available
- Run `make test` on the Docker image
  - If we want to work as `ubuntu` user, we need to hack with `sudo chown -R 1000:1000 ${{ github.workspace }}`
  - Because GHA will checkout files as `runner` user that has uid: `1001`, not uid: `1000`(ubuntu)